### PR TITLE
Vcf extension change

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -14,7 +14,7 @@
       "help": "A VCF file containing variants to be annotated",
       "class": "file",
       "optional": false,
-      "patterns": ["*.refseq_nirvana_203.vcf"]
+      "patterns": ["*.vcf"]
     }
   ],
   "outputSpec": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -14,7 +14,7 @@
       "help": "A VCF file containing variants to be annotated",
       "class": "file",
       "optional": false,
-      "patterns": ["*.vcf", "*vcf.gz"]
+      "patterns": ["*.vcf", "*.vcf.gz"]
     }
   ],
   "outputSpec": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -14,7 +14,7 @@
       "help": "A VCF file containing variants to be annotated",
       "class": "file",
       "optional": false,
-      "patterns": ["*.vcf"]
+      "patterns": ["*.vcf", "*vcf.gz"]
     }
   ],
   "outputSpec": [


### PR DESCRIPTION
Allow .vcf, .vcf.gz input. 
Do not require refseq_nirvana_203.vcf extension for input.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_nirvana/7)
<!-- Reviewable:end -->
